### PR TITLE
Fix dplyr & rcolorbrewer warnings

### DIFF
--- a/R/multiple.R
+++ b/R/multiple.R
@@ -96,6 +96,12 @@ NULL
                        })
     do.call(tagList, measures)
   })
+  
+  # save the 8-colour palette "Dark2" from RColorBrewer. We do this, otherwise it
+  # shows many warnings when number of groups > 8 (colours are reused when displayed)
+  # Related answer here:
+  # https://stackoverflow.com/questions/38740837/custom-discrete-color-scale-in-plotly
+  group_colors <- RColorBrewer::brewer.pal(8, "Dark2")
 
 
   # save uploaded data and update options
@@ -313,7 +319,7 @@ NULL
     }
 
     plt <- plotly::plot_ly(type = "scatter", x = ages, y = y_data, 
-                           color = plot_name, colors = "Dark2", 
+                           color = plot_name, colors = group_colors, 
                            mode = plot_mode, showlegend = FALSE) %>% 
       plotly::layout(xaxis = list(title = paste0("Age (", age_unit, ")")), 
                      yaxis = list(title = y_title))

--- a/R/single.R
+++ b/R/single.R
@@ -157,8 +157,8 @@ NULL
     df <- df[df$code %in% calculated_measurements$.codes,]
     
     # all the columns are double except 'code' and 'Centile' columns (keep them as string)
-    df <- df %>% dplyr::tbl_df(.) %>% 
-      dplyr::mutate_at(grep("code|Centile", colnames(.), invert=T), dplyr::funs(as.numeric)) %>% 
+    df <- tibble::as_tibble(df) %>% 
+      dplyr::mutate_at(grep("code|Centile", colnames(.), invert=T), list(~as.numeric(.))) %>% 
       dplyr::mutate_if(is.numeric, round, 2) %>% 
       as.data.frame()
     


### PR DESCRIPTION
Fixes #46. 

The remaining`arrange_()` warning is from the plotly package. Their [fix](https://github.com/ropensci/plotly/pull/1821) has been merged into plotly master but there hasn't been a new release on CRAN. I suggest waiting for the release and tolerating the warning for now.
