### PR TITLE
Travis config to check and build package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
 language: r
 
+r:
+  - oldrel
+  - release
+
 os:
   - linux
   - osx
 
 cache:
-  directories:
-    - $HOME/R/Library
-    - $TRAVIS_BUILD_DIR/packrat/src
-    - $TRAVIS_BUILD_DIR/packrat/lib
   packages: true
 
 addons:
   apt:
     packages:
     - libv8-dev
-
-install:
-  - R -e "install.packages(c('devtools', 'usethis', 'testthat', 'packrat'))"
-  - R -e "0" --args --bootstrap-packrat
-  - R -e "packrat::restore(restart = FALSE)"
-
-script:
-  - R -e "devtools::test()"


### PR DESCRIPTION
This config runs `R build` and `R check` on the LMSgrowth2 package on linux+osx and an old release (v3) and current release (v4) of R.
