### PR TITLE
Upgrade libs & fix for 4.0.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Author: Tim Cole, Mosè Giordano, Asif U Tamuri
 Maintainer: Tim Cole <tim.cole@ucl.ac.uk>
 Description: A web application for working with growth references using the LMS method.
 License: file LICENSE
-Imports: dplyr, shiny, shinyjs, purrr, stringr, plotly, DT, formattable, shinyWidgets, sitar, uuid, rio, V8, shinyhelper
+Imports: dplyr, shiny, shinyjs, purrr, stringr, plotly, DT, formattable, shinyWidgets, sitar, uuid, rio, V8, shinyhelper, tibble
 Encoding: UTF-8
 LazyData: true
 Suggests: 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@
 # To run, specify directory on host to persist user uploads
 # docker run --publish 3838:3838 -v <host dir for uploads>:/srv/shiny-server/LMSgrowth2/inst/uploads lmsgrowth2
 
-FROM rocker/shiny:3.6.3
+FROM rocker/shiny:4.0.4
 
 RUN apt-get update && apt-get -y install libcurl4-gnutls-dev libgit2-dev libssh2-1-dev libssl-dev libv8-dev libxml2-dev
 
 RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site
 
-RUN R -e "install.packages(c('dplyr', 'shiny', 'shinyjs', 'purrr', 'stringr', 'plotly', 'DT', 'formattable', 'shinyWidgets', 'sitar', 'uuid', 'rio', 'V8', 'shinyhelper'))"
+RUN R -e "install.packages(c('devtools', 'dplyr', 'shiny', 'shinyjs', 'purrr', 'stringr', 'plotly', 'DT', 'formattable', 'shinyWidgets', 'sitar', 'uuid', 'rio', 'V8', 'shinyhelper', 'tibble'))"
 
 COPY . /srv/shiny-server/LMSgrowth2
 

--- a/R/main.R
+++ b/R/main.R
@@ -20,7 +20,7 @@ utils::globalVariables('.')
   tagList(
     tags$script(src="LMSgrowth2/js.cookie.js"),
     shinyjs::useShinyjs(),
-    shinyjs::extendShinyjs(script=system.file('assets', 'shinyjs.js', package='LMSgrowth2')),
+    shinyjs::extendShinyjs(script='LMSgrowth2/shinyjs.js', functions=c("getcookies", "setcookie", "rmcookie", "rmcookies")),
     navbarPage(
       "LMSgrowth2",
       tabPanel("One child", .singleUI("single")),

--- a/R/single.R
+++ b/R/single.R
@@ -157,8 +157,9 @@ NULL
     df <- df[df$code %in% calculated_measurements$.codes,]
     
     # all the columns are double except 'code' and 'Centile' columns (keep them as string)
-    df <- df %>% dplyr::tbl_df(.) %>% 
-      dplyr::mutate_at(grep("code|Centile", colnames(.), invert=T), dplyr::funs(as.numeric)) %>% 
+    df <- df %>% tibble::as_tibble(.) %>% 
+      # dplyr::mutate_at(grep("code|Centile", colnames(.), invert=T), dplyr::funs(as.numeric)) %>% 
+      dplyr::mutate(across(grep("code|Centile", colnames(.), invert=T), as.numeric)) %>%
       dplyr::mutate_if(is.numeric, round, 2) %>% 
       as.data.frame()
     

--- a/R/single.R
+++ b/R/single.R
@@ -159,7 +159,7 @@ NULL
     # all the columns are double except 'code' and 'Centile' columns (keep them as string)
     df <- df %>% tibble::as_tibble(.) %>% 
       # dplyr::mutate_at(grep("code|Centile", colnames(.), invert=T), dplyr::funs(as.numeric)) %>% 
-      dplyr::mutate(across(grep("code|Centile", colnames(.), invert=T), as.numeric)) %>%
+      dplyr::mutate(dplyr::across(grep("code|Centile", colnames(.), invert=T), as.numeric)) %>%
       dplyr::mutate_if(is.numeric, round, 2) %>% 
       as.data.frame()
     

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -1,34 +1,35 @@
 PackratFormat: 1.4
-PackratVersion: 0.5.0.25
-RVersion: 4.0.2
-Repos: CRAN=https://cran.rstudio.com/
+PackratVersion: 0.5.0
+RVersion: 4.0.4
+Repos: CRAN=https://cran.ma.imperial.ac.uk
 
 Package: BH
 Source: CRAN
-Version: 1.72.0-3
-Hash: fc53be86f0b712d3de03fef95893d710
-
-Package: Cairo
-Source: CRAN
-Version: 1.5-12.2
-Hash: a85cf5fd08393ba3cf3d207d193dd662
+Version: 1.75.0-0
+Hash: 8426697ec75df1ac7b9bc664741f383a
 
 Package: DT
 Source: CRAN
-Version: 0.14
-Hash: 6c16d3f1905629a74851987734a4d33e
+Version: 0.17
+Hash: 1087d0106ce6f1093428ca3882748d38
 Requires: crosstalk, htmltools, htmlwidgets, jsonlite, magrittr,
     promises
 
-Package: MatrixModels
+Package: MASS
 Source: CRAN
-Version: 0.4-1
-Hash: 60a5c75e57aae4a0ce76cb7422939aaf
+Version: 7.3-53
+Hash: 34151e53eabf74b94c982a0d1f4a7f79
+
+Package: Matrix
+Source: CRAN
+Version: 1.3-2
+Hash: afdf15d578041a5ed0a722bc346b5269
+Requires: lattice
 
 Package: R6
 Source: CRAN
-Version: 2.4.1
-Hash: b488861d8c3dfac497e041ec911df9fb
+Version: 2.5.0
+Hash: 25ebbd2664a276c915984da5c820c404
 
 Package: RColorBrewer
 Source: CRAN
@@ -37,18 +38,13 @@ Hash: c0d56cd15034f395874c870141870c25
 
 Package: Rcpp
 Source: CRAN
-Version: 1.0.5
-Hash: f6e400231df42179d6ce8fb35e52bf3f
-
-Package: SparseM
-Source: CRAN
-Version: 1.78
-Hash: deb628f138abd8575037bcf662a99259
+Version: 1.0.6
+Hash: d891b607ea796cf30abfe4795380423f
 
 Package: V8
 Source: CRAN
-Version: 3.2.0
-Hash: b8a087ee0190d0123fe34b57d840aaf9
+Version: 3.4.0
+Hash: 5fbd2164a5650f97c856d9fd7819a4c1
 Requires: Rcpp, curl, jsonlite
 
 Package: askpass
@@ -62,20 +58,32 @@ Source: CRAN
 Version: 0.2.1
 Hash: 622be49032fe50bd42e96aaef613e209
 
-Package: backports
-Source: CRAN
-Version: 1.1.8
-Hash: df2d529bbe7276f6280a5811eb4877b2
-
 Package: base64enc
 Source: CRAN
 Version: 0.1-3
 Hash: c590d29e555926af053055e23ee79efb
 
+Package: brio
+Source: CRAN
+Version: 1.1.1
+Hash: 14f5792a274142d1d69d32d454377844
+
+Package: bslib
+Source: CRAN
+Version: 0.2.4
+Hash: 2dcc37222856e66b36db2c1ad11b9bc0
+Requires: digest, htmltools, jquerylib, jsonlite, magrittr, rlang, sass
+
+Package: cachem
+Source: CRAN
+Version: 1.0.4
+Hash: 8ba7d0e3593d47517fbabf30860d0eeb
+Requires: fastmap, rlang
+
 Package: callr
 Source: CRAN
-Version: 3.4.3
-Hash: e9b50bc56e655025fde6f2f4b65154de
+Version: 3.5.1
+Hash: f9c95688940b93248943b187e998d743
 Requires: R6, processx
 
 Package: cellranger
@@ -86,34 +94,44 @@ Requires: rematch, tibble
 
 Package: cli
 Source: CRAN
-Version: 2.0.2
-Hash: 6fc0b39f0fdbe3a025062807019e1180
-Requires: assertthat, crayon, fansi, glue
+Version: 2.3.1
+Hash: bd498ff53cd3e1a0fa501bcbcb785bf0
+Requires: assertthat, glue
 
 Package: clipr
 Source: CRAN
-Version: 0.7.0
-Hash: 30cdec6c8cc62c80c485e6bdd0c02b05
+Version: 0.7.1
+Hash: 50bca21c0c36d24984b051077cb15cf3
+
+Package: codetools
+Source: CRAN
+Version: 0.2-18
+Hash: 1225ba881d465058ec055509e1d58540
 
 Package: colorspace
 Source: CRAN
-Version: 1.4-1
-Hash: 60a56e9998b8b58ee378db3dc91b27a5
+Version: 2.0-0
+Hash: 70357b46371ef626b2fc3968df10b94a
 
 Package: commonmark
 Source: CRAN
 Version: 1.7
 Hash: 77f4ba718e2bad1877ef26e48cf8fa43
 
+Package: cpp11
+Source: CRAN
+Version: 0.2.6
+Hash: 95f5bc84c456bb0a66bcad5ac725368c
+
 Package: crayon
 Source: CRAN
-Version: 1.3.4
-Hash: ff2840dd9b0d563fc80377a5a45510cd
+Version: 1.4.1
+Hash: 2e1b6e4b4bc63ebe2aaee1546b871329
 
 Package: crosstalk
 Source: CRAN
-Version: 1.1.0.1
-Hash: 0074e4967b2db46d003c5d23e4519306
+Version: 1.1.1
+Hash: 40844571ab8c7b3009cde6e49a1ace16
 Requires: R6, htmltools, jsonlite, lazyeval
 
 Package: curl
@@ -123,38 +141,32 @@ Hash: 3916ae5637dbaf5996dbde80ea92a047
 
 Package: data.table
 Source: CRAN
-Version: 1.12.8
-Hash: 283ad0e503ab521300c6d1d02e58d2ae
-
-Package: debugme
-Source: CRAN
-Version: 1.1.0
-Hash: c233690edd9fa17a63f7c8d83c1ca153
-Requires: crayon
+Version: 1.14.0
+Hash: f606b167539da14e861ff5e145b04525
 
 Package: desc
 Source: CRAN
-Version: 1.2.0
-Hash: a0a3ca939997679a52816bae4ed6aaae
-Requires: R6, assertthat, crayon, rprojroot
+Version: 1.3.0
+Hash: 3f74548f278428b009b0a31ba8d79302
+Requires: R6, crayon, rprojroot
+
+Package: diffobj
+Source: CRAN
+Version: 0.3.3
+Hash: ddcc5427ba555b313c0943b465a6619b
+Requires: crayon
 
 Package: digest
 Source: CRAN
-Version: 0.6.25
-Hash: ec0a673866797c8c1fc1daa359fb4cad
+Version: 0.6.27
+Hash: 8ba156629c1537635b39332c93d8ed33
 
 Package: dplyr
 Source: CRAN
-Version: 1.0.0
-Hash: 4db17ac7cad6ce9c544dc8fc9709a75b
+Version: 1.0.5
+Hash: 22ea7606f5565fb879d9f3b51ffb0e46
 Requires: R6, ellipsis, generics, glue, lifecycle, magrittr, rlang,
     tibble, tidyselect, vctrs
-
-Package: dygraphs
-Source: CRAN
-Version: 1.1.1.6
-Hash: d79b4000362792fec89263172aabb541
-Requires: htmltools, htmlwidgets, magrittr, xts, zoo
 
 Package: ellipsis
 Source: CRAN
@@ -169,63 +181,75 @@ Hash: 18306cc3bc1aec7b7360eea8a0eb0ee1
 
 Package: fansi
 Source: CRAN
-Version: 0.4.1
-Hash: fc0a252b8e427847d13e89f56ab4665e
+Version: 0.4.2
+Hash: 46ab61226bcca6890ad4864250f62a0e
 
 Package: farver
 Source: CRAN
-Version: 2.0.3
-Hash: 29a358c21cb8de2e424cbec6b6be6553
+Version: 2.1.0
+Hash: a001f1816f74d0e76e82171eef764a9d
 
 Package: fastmap
 Source: CRAN
-Version: 1.0.1
-Hash: d272cd728e4095b3964181b44763f46c
+Version: 1.1.0
+Hash: e4d212b14d40b91c791c0b9d3b6ffd99
 
 Package: forcats
 Source: CRAN
-Version: 0.5.0
-Hash: 6b130778caccc8e4e6cf498c76c84e7b
+Version: 0.5.1
+Hash: d95e6deaed2fcb1f74a7764f42524fc2
 Requires: ellipsis, magrittr, rlang, tibble
+
+Package: foreign
+Source: CRAN
+Version: 0.8-81
+Hash: 53f23dff824a3b365aa8065e42b84b71
 
 Package: formattable
 Source: CRAN
-Version: 0.2.0.1
-Hash: 64836860c4666eadc229c6e47fdd2261
+Version: 0.2.1
+Hash: c7c27666bc959801c721e4372bd4bf94
 Requires: htmltools, htmlwidgets, knitr, rmarkdown
+
+Package: fs
+Source: CRAN
+Version: 1.5.0
+Hash: 918ea5c88cad73d5d5b529ca98f8ad11
 
 Package: furrr
 Source: CRAN
-Version: 0.1.0
-Hash: 2bf07dd5ce0ab262a081cc9f0555b670
-Requires: future, globals, purrr, rlang
+Version: 0.2.2
+Hash: 646ca3aa973161e2dee99b3eb26c2d14
+Requires: ellipsis, future, globals, lifecycle, purrr, rlang, vctrs
 
 Package: future
 Source: CRAN
-Version: 1.17.0
-Hash: 722958b10986bdc608c38efd0b9de2f0
-Requires: digest, globals, listenv
+Version: 1.21.0
+Hash: 0d3d84f2f3c700ca5e90301a1ae013a0
+Requires: digest, globals, listenv, parallelly
 
 Package: generics
 Source: CRAN
-Version: 0.0.2
-Hash: 4aaf002dd434e8c854611c5d11a1d58e
+Version: 0.1.0
+Hash: c265031f21f6435ffaa9633eb64c3095
 
 Package: ggplot2
 Source: CRAN
-Version: 3.3.2
-Hash: e5836c08c1243c1fc26608f708fc1d8c
-Requires: digest, glue, gtable, isoband, rlang, scales, tibble, withr
+Version: 3.3.3
+Hash: fcae8a1c452b7bf7e5b11d1d438c825e
+Requires: MASS, digest, glue, gtable, isoband, mgcv, rlang, scales,
+    tibble, withr
 
 Package: globals
 Source: CRAN
-Version: 0.12.5
-Hash: 93c51eaf39b178fd11ff574d3eae5b88
+Version: 0.14.0
+Hash: f3f53bb33854c4c4da34c11ad80ee96a
+Requires: codetools
 
 Package: glue
 Source: CRAN
-Version: 1.4.1
-Hash: 740ccee1066d96aeb3f4d1e571245913
+Version: 1.4.2
+Hash: afa798ba9deec3676e20300b79094749
 
 Package: gtable
 Source: CRAN
@@ -235,13 +259,8 @@ Hash: a9e7b0666eb933a0cb36779240b4462e
 Package: haven
 Source: CRAN
 Version: 2.3.1
-Hash: 78892c0f68dbf1bdef92992a74ecdec2
+Hash: 810aa9a10646b1289a83d86489e369a5
 Requires: Rcpp, forcats, hms, readr, rlang, tibble, tidyselect, vctrs
-
-Package: hexbin
-Source: CRAN
-Version: 1.28.1
-Hash: 38f5e8c7439a986fee82ec0651c5eb39
 
 Package: highr
 Source: CRAN
@@ -250,61 +269,71 @@ Hash: 16aa2cc98d7b68c9d148c263c8dcdbcd
 
 Package: hms
 Source: CRAN
-Version: 0.5.3
-Hash: a0709e1b17b4bc1c27f5235177543e07
-Requires: pkgconfig, rlang, vctrs
+Version: 1.0.0
+Hash: 045f4f0c5af5611f42b19cfd492dd78d
+Requires: ellipsis, lifecycle, pkgconfig, rlang, vctrs
 
 Package: htmltools
 Source: CRAN
-Version: 0.5.0
-Hash: 79070a001acba57f88692d17e859bac5
+Version: 0.5.1.1
+Hash: 297e3b95a781d9a6fb7259e0f6824020
 Requires: base64enc, digest, rlang
 
 Package: htmlwidgets
 Source: CRAN
-Version: 1.5.1
-Hash: 20e5cc02b795afc7322836c947b5aab2
+Version: 1.5.3
+Hash: 6405f8f000f8a52e0dc2f034b3693fe5
 Requires: htmltools, jsonlite, yaml
 
 Package: httpuv
 Source: CRAN
-Version: 1.5.4
-Hash: 8c8e24cfefa0977e389e458129cf96e3
+Version: 1.5.5
+Hash: 0fe8bcd75ab4a1817c59618d0c2e0318
 Requires: BH, R6, Rcpp, later, promises
 
 Package: httr
 Source: CRAN
-Version: 1.4.1
-Hash: cc16de93eaabd3c6d0785cb8e6d059ab
+Version: 1.4.2
+Hash: 2ad813eba37ce1f357434789aa8b6132
 Requires: R6, curl, jsonlite, mime, openssl
 
 Package: isoband
 Source: CRAN
-Version: 0.2.2
-Hash: 2264002205b89ba462ceb55c6edad2ea
-Requires: testthat
+Version: 0.2.4
+Hash: b1e8c5547c2e0b0b45f375da77325ed2
+
+Package: jquerylib
+Source: CRAN
+Version: 0.1.3
+Hash: a120a9e6dc9f493b41848e8a16276454
+Requires: htmltools
 
 Package: jsonlite
 Source: CRAN
-Version: 1.7.0
-Hash: dec188bcfae1bb0fba6731c9aee6a9d2
+Version: 1.7.2
+Hash: a5965fb563ba3643e75c425a82f935e6
 
 Package: knitr
 Source: CRAN
-Version: 1.29
-Hash: 092d44a49b645731ffe88d41be022f01
+Version: 1.31
+Hash: b28bf08b1a7636ae679fae434720b592
 Requires: evaluate, highr, markdown, stringr, xfun, yaml
 
 Package: labeling
 Source: CRAN
-Version: 0.3
-Hash: ecf589b42cd284b03a4beb9665482d3e
+Version: 0.4.2
+Hash: 7474c78957f4e01d1dd4c04217eab244
 
 Package: later
 Source: CRAN
 Version: 1.1.0.1
-Hash: 0c6d0dbad70a1b8698919b5d70e8a430
+Hash: 9297fba870b633894f5f8f76f6fc2234
 Requires: BH, Rcpp, rlang
+
+Package: lattice
+Source: CRAN
+Version: 0.20-41
+Hash: ff87ada677a6e2aacdcc1f9412f68366
 
 Package: lazyeval
 Source: CRAN
@@ -313,8 +342,8 @@ Hash: 563563691bea3cde6945a98996d7c166
 
 Package: lifecycle
 Source: CRAN
-Version: 0.2.0
-Hash: df8649860c43571aab68cc73a2a02807
+Version: 1.0.0
+Hash: 0c18dc7a4e21abdc8132b7cac2b5fcb4
 Requires: glue, rlang
 
 Package: listenv
@@ -324,8 +353,8 @@ Hash: 1e47a0224c5b814c05161cf2da491b2c
 
 Package: magrittr
 Source: CRAN
-Version: 1.5
-Hash: bdc4d48c3135e8f3b399536ddf160df4
+Version: 2.0.1
+Hash: d3c166b0573ae8c918edf7221dfe7380
 
 Package: markdown
 Source: CRAN
@@ -333,10 +362,16 @@ Version: 1.1
 Hash: 1b6a18fd395589425e338a47b999099f
 Requires: mime, xfun
 
+Package: mgcv
+Source: CRAN
+Version: 1.8-33
+Hash: 5ee3b1282cd29db13e872366e0a7be33
+Requires: Matrix, nlme
+
 Package: mime
 Source: CRAN
-Version: 0.9
-Hash: f3388735b4ddea072aff3be44f7f4968
+Version: 0.10
+Hash: 20b0f90f3478d2baae76be49777ac9fe
 
 Package: munsell
 Source: CRAN
@@ -344,49 +379,44 @@ Version: 0.5.0
 Hash: 38d0efee9bb99bef143bde41c4ce715c
 Requires: colorspace
 
+Package: nlme
+Source: CRAN
+Version: 3.1-152
+Hash: 3761e6e8818069c15c0d04deef664201
+Requires: lattice
+
 Package: openssl
 Source: CRAN
-Version: 1.4.2
-Hash: 4a0f5345a4c0dc1ee684fea405f879e8
+Version: 1.4.3
+Hash: cff3745af78f3fabe3175678c34b6510
 Requires: askpass
 
 Package: openxlsx
 Source: CRAN
-Version: 4.1.5
-Hash: cb063d8c8c99a5a2e8f769f09cf799ad
+Version: 4.2.3
+Hash: 93147efbc636cba5a917d76374eab1a2
 Requires: Rcpp, stringi, zip
 
 Package: packrat
-Source: github
-Version: 0.5.0-25
-Hash: 5dc775de8d1a4abac142a55045f72d84
-GithubRepo: packrat
-GithubUsername: rstudio
-GithubRef: master
-GithubSha1: 448aafd176ec6cbde307f556c91b39e5a1c94f9d
-
-Package: parsedate
 Source: CRAN
-Version: 1.2.0
-Hash: 289aca3d85861a48b5a91aa2c49fbe50
-Requires: rematch2
+Version: 0.5.0
+Hash: 498643e765d1442ba7b1160a1df3abf9
+
+Package: parallelly
+Source: CRAN
+Version: 1.23.0
+Hash: 0b321920e97270b88542b40329578ed2
 
 Package: pillar
 Source: CRAN
-Version: 1.4.4
-Hash: a49a235ae5deaefbb3f6053d67dc64d0
-Requires: cli, crayon, fansi, rlang, utf8, vctrs
-
-Package: pingr
-Source: CRAN
-Version: 2.0.1
-Hash: 6414ad7500383eb5965ea101a5015d0c
-Requires: processx
+Version: 1.5.1
+Hash: e8b4035f2e3b04e2262577360387884a
+Requires: cli, crayon, ellipsis, fansi, lifecycle, rlang, utf8, vctrs
 
 Package: pkgbuild
 Source: CRAN
-Version: 1.0.8
-Hash: 7f686e4c50ab63ae95537067d577de3f
+Version: 1.2.0
+Hash: 5b2b394083875853add40c2d264523f7
 Requires: R6, callr, cli, crayon, desc, prettyunits, rprojroot, withr
 
 Package: pkgconfig
@@ -396,35 +426,19 @@ Hash: 5ff5f2361851a49534c96caa2a8071c7
 
 Package: pkgload
 Source: CRAN
-Version: 1.1.0
-Hash: a65ac8a100a65cff8e5e4a122d2a51af
+Version: 1.2.0
+Hash: 403f2ed3bfb9976e94da51358b25dd6e
 Requires: cli, crayon, desc, pkgbuild, rlang, rprojroot, rstudioapi,
     withr
 
-Package: plogr
-Source: CRAN
-Version: 0.2.0
-Hash: 81a8008a5e7858552503935f1abe48aa
-
 Package: plotly
 Source: CRAN
-Version: 4.9.2.1
-Hash: eeb9c83733cd3c9852c727b48678ce9a
+Version: 4.9.3
+Hash: cd9325fd1ed2af834bdc5434f6f45c19
 Requires: RColorBrewer, base64enc, crosstalk, data.table, digest,
-    dplyr, ggplot2, hexbin, htmltools, htmlwidgets, httr, jsonlite,
-    lazyeval, magrittr, promises, purrr, rlang, scales, tibble, tidyr,
+    dplyr, ggplot2, htmltools, htmlwidgets, httr, jsonlite, lazyeval,
+    magrittr, promises, purrr, rlang, scales, tibble, tidyr, vctrs,
     viridisLite
-
-Package: plyr
-Source: CRAN
-Version: 1.8.6
-Hash: 843fdf947862e66a51fc94b930519abc
-Requires: Rcpp
-
-Package: png
-Source: CRAN
-Version: 0.1-7
-Hash: 421d7d6e0fb4bd885ecbd909b6456b8b
 
 Package: praise
 Source: CRAN
@@ -438,8 +452,8 @@ Hash: 20669cd8bb8b3207f6371edf8cf510af
 
 Package: processx
 Source: CRAN
-Version: 3.4.3
-Hash: 7bfe7314749a60dfaf93985b6e541e24
+Version: 3.4.5
+Hash: f136ca3e48b88288669ee4f6c2fe199a
 Requires: R6, ps
 
 Package: progress
@@ -450,14 +464,14 @@ Requires: R6, crayon, hms, prettyunits
 
 Package: promises
 Source: CRAN
-Version: 1.1.1
-Hash: 0f58aaef1b398b33f902cd50cb50d2d0
+Version: 1.2.0.1
+Hash: e1b84208834fc1e2e75099ec002b7904
 Requires: R6, Rcpp, later, magrittr, rlang
 
 Package: ps
 Source: CRAN
-Version: 1.3.3
-Hash: 017cf9da2d29e4134b5e3e58176a87ad
+Version: 1.6.0
+Hash: ff1b2fafdb6239700fdf0f96f99cce87
 
 Package: purrr
 Source: CRAN
@@ -465,34 +479,22 @@ Version: 0.3.4
 Hash: fb4c0edca61826ca0b5b33c828a7b276
 Requires: magrittr, rlang
 
-Package: quantreg
+Package: rappdirs
 Source: CRAN
-Version: 5.55
-Hash: 8518ba15058ddb0932d7b0d815a607f4
-Requires: MatrixModels, SparseM
-
-Package: ragg
-Source: CRAN
-Version: 0.3.1
-Hash: 2913991b8c016c661a362a1149bf4774
-Requires: systemfonts
-
-Package: reactlog
-Source: CRAN
-Version: 1.0.0
-Hash: 2cc6340cef36254b564e55c68416e38d
-Requires: jsonlite
+Version: 0.3.3
+Hash: fd602edfd7dbf365642e35dd9cc97958
 
 Package: readr
 Source: CRAN
-Version: 1.3.1
-Hash: b38fa28b383389095863c05fa54de9b8
-Requires: BH, R6, Rcpp, clipr, crayon, hms, tibble
+Version: 1.4.0
+Hash: 18b5823ea915dcb371ed38407391aff3
+Requires: BH, R6, cli, clipr, cpp11, crayon, hms, lifecycle, rlang,
+    tibble
 
 Package: readxl
 Source: CRAN
 Version: 1.3.1
-Hash: e0d3207127ab34491c9e30c6e1e9495c
+Hash: e34982e51b2fb433409a36da8111439f
 Requires: Rcpp, cellranger, progress, tibble
 
 Package: rematch
@@ -506,47 +508,46 @@ Version: 2.1.2
 Hash: b6823f74d6525d39d153620d21e206df
 Requires: tibble
 
-Package: reshape2
-Source: CRAN
-Version: 1.4.4
-Hash: 7523bbd6a9f0e07c701adf4e1365bd7b
-Requires: Rcpp, plyr, stringr
-
 Package: rio
 Source: CRAN
-Version: 0.5.16
-Hash: 2f4c960bbac0fc50cf19f5aebf42d82c
-Requires: curl, data.table, haven, openxlsx, readxl, tibble
+Version: 0.5.26
+Hash: 3b761463ef2fa3f3103296624c59d7a1
+Requires: curl, data.table, foreign, haven, openxlsx, readxl, tibble
 
 Package: rlang
 Source: CRAN
-Version: 0.4.6
-Hash: 961439fc46343c94eb50973664feee76
+Version: 0.4.10
+Hash: eb6b577ea2302f9617b010ae4f64a912
 
 Package: rmarkdown
 Source: CRAN
-Version: 2.3
-Hash: 1352d23bb0973c09ee9d181fe3271258
-Requires: base64enc, evaluate, htmltools, jsonlite, knitr, mime,
-    stringr, tinytex, xfun, yaml
+Version: 2.7
+Hash: c91cec3f2386371b7bb24209887ed8ce
+Requires: evaluate, htmltools, jsonlite, knitr, stringr, tinytex, xfun,
+    yaml
 
 Package: rprojroot
 Source: CRAN
-Version: 1.3-2
-Hash: a25c3f70c166fb3fbabc410eb32b6366
-Requires: backports
+Version: 2.0.2
+Hash: bdb6a7f2b3c25b8c710615cefdde1af0
 
 Package: rsample
 Source: CRAN
-Version: 0.0.7
-Hash: 362c465c206113ed015c527bc970e282
-Requires: dplyr, furrr, generics, purrr, rlang, tibble, tidyr,
-    tidyselect, vctrs
+Version: 0.0.9
+Hash: d860966995cebac47771957629129669
+Requires: dplyr, ellipsis, furrr, generics, purrr, rlang, slider,
+    tibble, tidyr, tidyselect, vctrs
 
 Package: rstudioapi
 Source: CRAN
-Version: 0.11
-Hash: f8674fe40760ccfc1bf3e92da4c9f4d0
+Version: 0.13
+Hash: dab1619920bed1f1660a3d48e4f7cc7f
+
+Package: sass
+Source: CRAN
+Version: 0.3.1
+Hash: 8ab047f6c1a318e9bb8cabfc368f538c
+Requires: R6, digest, fs, htmltools, rappdirs, rlang
 
 Package: scales
 Source: CRAN
@@ -557,16 +558,16 @@ Requires: R6, RColorBrewer, farver, labeling, lifecycle, munsell,
 
 Package: shiny
 Source: CRAN
-Version: 1.5.0
-Hash: c6e7eb15d6cd1f0f21b6afe871d6e106
-Requires: R6, commonmark, crayon, digest, fastmap, glue, htmltools,
-    httpuv, jsonlite, later, mime, promises, rlang, sourcetools, withr,
-    xtable
+Version: 1.6.0
+Hash: 35e21ce401cc3b1fae93a190b32f6a65
+Requires: R6, bslib, cachem, commonmark, crayon, digest, ellipsis,
+    fastmap, glue, htmltools, httpuv, jsonlite, later, lifecycle, mime,
+    promises, rlang, sourcetools, withr, xtable
 
 Package: shinyWidgets
 Source: CRAN
-Version: 0.5.3
-Hash: 38209297307be9249b6012a95b84f43d
+Version: 0.5.7
+Hash: f1ef14fe1508f326a373532f928df79d
 Requires: htmltools, jsonlite, shiny
 
 Package: shinyhelper
@@ -577,41 +578,21 @@ Requires: markdown, shiny
 
 Package: shinyjs
 Source: CRAN
-Version: 1.1
-Hash: 1998b94e4425bcc71539e897bceed880
+Version: 2.0.0
+Hash: 76cd028f38d0c5a1f198c4daab81ddfe
 Requires: digest, htmltools, jsonlite, shiny
-
-Package: shinytest
-Source: CRAN
-Version: 1.4.0
-Hash: 40ed14454e1055122ad85ae5d76ac17d
-Requires: R6, assertthat, callr, crayon, debugme, digest, htmlwidgets,
-    httpuv, httr, jsonlite, parsedate, pingr, rematch, rstudioapi,
-    shiny, testthat, webdriver, withr
-
-Package: showimage
-Source: CRAN
-Version: 1.0.0
-Hash: f058f6b423455d7267a39f920b1d1a64
-Requires: png
-
-Package: showtext
-Source: CRAN
-Version: 0.8-1
-Hash: 35370ab815999a39de56d58d5fd5b314
-Requires: showtextdb, sysfonts
-
-Package: showtextdb
-Source: CRAN
-Version: 3.0
-Hash: a96c257694c778656e67c4e60186c4b2
-Requires: sysfonts
 
 Package: sitar
 Source: CRAN
 Version: 1.1.2
 Hash: 3ec6f3139377842d02a91f2b7618b82f
-Requires: dplyr, glue, purrr, rlang, rsample, tibble, tidyr
+Requires: dplyr, glue, nlme, purrr, rlang, rsample, tibble, tidyr
+
+Package: slider
+Source: CRAN
+Version: 0.1.5
+Hash: 933b05cd4f4370b57cb9b3a1a102b4ea
+Requires: glue, rlang, vctrs, warp
 
 Package: sourcetools
 Source: CRAN
@@ -620,8 +601,8 @@ Hash: d093478ac90064e670cd4bf1a99b47b6
 
 Package: stringi
 Source: CRAN
-Version: 1.4.6
-Hash: 076b0f115b37ca6d551ccff96b91114e
+Version: 1.5.3
+Hash: 30919ce6e9ad5bb8e9fcb1ed59ebcd6e
 
 Package: stringr
 Source: CRAN
@@ -631,39 +612,30 @@ Requires: glue, magrittr, stringi
 
 Package: sys
 Source: CRAN
-Version: 3.3
-Hash: d5a4afad9298f42aae77f6389713a066
-
-Package: sysfonts
-Source: CRAN
-Version: 0.8.1
-Hash: 80c4f1a5c0d3894c2b1df0fdb3732a49
-
-Package: systemfonts
-Source: CRAN
-Version: 0.2.3
-Hash: 84a93000dd933c32f83f949f3e62f46f
+Version: 3.4
+Hash: 7fb0c9e1209a804b329a7df3cd422008
 
 Package: testthat
 Source: CRAN
-Version: 2.3.2
-Hash: 5a3a20ddc31b2aa228dab6d29bd43948
-Requires: R6, cli, crayon, digest, ellipsis, evaluate, magrittr,
-    pkgload, praise, rlang, withr
+Version: 3.0.2
+Hash: 9bcc1a95e57fd187fc8a874107a9220b
+Requires: R6, brio, callr, cli, crayon, desc, digest, ellipsis,
+    evaluate, jsonlite, lifecycle, magrittr, pkgload, praise, processx,
+    ps, rlang, waldo, withr
 
 Package: tibble
 Source: CRAN
-Version: 3.0.2
-Hash: 98588bf21d007b2f5320dfb2ee9e93a2
-Requires: cli, crayon, ellipsis, fansi, lifecycle, magrittr, pillar,
-    pkgconfig, rlang, vctrs
+Version: 3.1.0
+Hash: dc23e5489c99bc632dbbda88792300e9
+Requires: ellipsis, fansi, lifecycle, magrittr, pillar, pkgconfig,
+    rlang, vctrs
 
 Package: tidyr
 Source: CRAN
-Version: 1.1.0
-Hash: 56a31368e0f2126c8cab723c70e099c0
-Requires: Rcpp, dplyr, ellipsis, glue, lifecycle, magrittr, purrr,
-    rlang, stringi, tibble, tidyselect, vctrs
+Version: 1.1.3
+Hash: 294fbb17d0f50fb293860357e45fa825
+Requires: cpp11, dplyr, ellipsis, glue, lifecycle, magrittr, purrr,
+    rlang, tibble, tidyselect, vctrs
 
 Package: tidyselect
 Source: CRAN
@@ -673,8 +645,8 @@ Requires: ellipsis, glue, purrr, rlang, vctrs
 
 Package: tinytex
 Source: CRAN
-Version: 0.24
-Hash: 15e691a029e4b9d399fbcadce5fd03dc
+Version: 0.30
+Hash: 1bb4c56c617a334cf17566fbc3bba42a
 Requires: xfun
 
 Package: utf8
@@ -689,8 +661,8 @@ Hash: b0fcab4d6aa43d97cf09e336b65b906f
 
 Package: vctrs
 Source: CRAN
-Version: 0.3.1
-Hash: bd8a497a3228d001519a2234d718c19c
+Version: 0.3.6
+Hash: 7640fab855dba3322264f50574e6bdcd
 Requires: digest, ellipsis, glue, rlang
 
 Package: viridisLite
@@ -698,33 +670,31 @@ Source: CRAN
 Version: 0.3.0
 Hash: 78bb072c4f9e729a283d4c40ec93f9c6
 
-Package: webdriver
+Package: waldo
 Source: CRAN
-Version: 1.0.5
-Hash: 886b77eebfb8ba4fbfa31935fb8fd19b
-Requires: R6, base64enc, callr, curl, debugme, httr, jsonlite,
-    showimage, withr
+Version: 0.2.4
+Hash: 995431b14706731ce38e6f10ce245fa4
+Requires: cli, diffobj, fansi, glue, rematch2, rlang, tibble
+
+Package: warp
+Source: CRAN
+Version: 0.2.0
+Hash: a5b5f39f730aa261667d0ee7a7d156f2
 
 Package: withr
 Source: CRAN
-Version: 2.2.0
-Hash: 709a3da4deef928ab299f4ff52caf66b
+Version: 2.4.1
+Hash: 490523cef72232b12a66f0e307e4ee7e
 
 Package: xfun
 Source: CRAN
-Version: 0.15
-Hash: cd6e03b0392374cf89622e8468854ff3
+Version: 0.21
+Hash: 19e28d9bc711b7b0d482e0a9e22bc92a
 
 Package: xtable
 Source: CRAN
 Version: 1.8-4
 Hash: dc0d47261b678d26032363bebd050540
-
-Package: xts
-Source: CRAN
-Version: 0.12-0
-Hash: 76d62c446276519363516ece8961a791
-Requires: zoo
 
 Package: yaml
 Source: CRAN
@@ -733,10 +703,5 @@ Hash: 424bc11cc358f23187feaa7978628196
 
 Package: zip
 Source: CRAN
-Version: 2.0.4
-Hash: f86b0ae5776b2e3880871fb0e34e5e48
-
-Package: zoo
-Source: CRAN
-Version: 1.8-8
-Hash: cc9534113f4513acb2f838ef8e2cd467
+Version: 2.1.1
+Hash: 127ef4d13fcabd6851527e5570b7aa5c

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -3,8 +3,7 @@ use.cache: FALSE
 print.banner.on.startup: auto
 vcs.ignore.lib: TRUE
 vcs.ignore.src: TRUE
-external.packages:
-    devtools
+external.packages: devtools
 local.repos: 
 load.external.packages.on.startup: TRUE
 ignored.packages: 


### PR DESCRIPTION
Hi @statist7. I noticed LMSgrowth2 was not working due to changes in latest versions of dplyr, tibble & shinyjs. This PR upgrades all the packages and makes necessary fixes.